### PR TITLE
#264 add abilities to commander chart tooltip

### DIFF
--- a/packages/web/src/components/charts/commanders-bar.tsx
+++ b/packages/web/src/components/charts/commanders-bar.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../coh/commanders";
 import { Avatar, Card } from "antd";
 import routes from "../../routes";
+import { CommanderAbilitiesComponent } from "../../pages/commanders/components";
 
 interface CommandersBarChartProps {
   commanders: Record<number, number>;
@@ -37,7 +38,7 @@ export const CommandersBarChart: React.FC<CommandersBarChartProps> = ({ commande
     return (
       <Card bodyStyle={{ padding: 5 }}>
         <Avatar
-          size={54}
+          size={86}
           shape="square"
           src={iconPath}
           style={{ display: "inline-block", verticalAlign: "top" }}
@@ -47,6 +48,7 @@ export const CommandersBarChart: React.FC<CommandersBarChartProps> = ({ commande
             {commanderData.commanderName} - {toolTipData.value}{" "}
           </b>
           <br />
+          <CommanderAbilitiesComponent commanderAbilities={commanderData.abilities} isSmall />
           <i>Click for more info ...</i>
         </div>
       </Card>

--- a/packages/web/src/pages/commanders/components.tsx
+++ b/packages/web/src/pages/commanders/components.tsx
@@ -6,17 +6,24 @@ import React from "react";
 
 type CommanderAbilityProps = {
   commanderAbilities: Array<CommanderAbility>;
-  commanderDescription: string;
+  commanderDescription?: string;
+  isSmall?: boolean;
 };
 
-export const CommanderAbilitiesComponent = (props: CommanderAbilityProps) => {
+export const CommanderAbilitiesComponent = ({
+  commanderAbilities,
+  commanderDescription,
+  isSmall,
+}: CommanderAbilityProps) => {
   return (
     <>
-      <Row style={{ paddingBottom: 25 }}>
-        <Text>{props.commanderDescription}</Text>
-      </Row>
+      {commanderDescription && (
+        <Row style={{ paddingBottom: 25 }}>
+          <Text>{commanderDescription}</Text>
+        </Row>
+      )}
       <Row>
-        {props.commanderAbilities.map((item: CommanderAbility) => {
+        {commanderAbilities.map((item: CommanderAbility) => {
           return (
             <Col key={item.name}>
               <Tooltip placement={"bottom"} title={item.description}>
@@ -24,13 +31,14 @@ export const CommanderAbilitiesComponent = (props: CommanderAbilityProps) => {
                   alt={item.name}
                   src={getExportedIconPath(item.icon)}
                   shape="square"
-                  size={64}
+                  size={isSmall ? 48 : 64}
                 />
                 <Badge
                   count={item.commandPoints}
                   overflowCount={999}
                   showZero
-                  offset={[-16, -32]}
+                  offset={isSmall ? OFFSET_SMALL : OFFSET_DEFAULT}
+                  size={isSmall ? "small" : "default"}
                 />
               </Tooltip>
             </Col>
@@ -40,3 +48,6 @@ export const CommanderAbilitiesComponent = (props: CommanderAbilityProps) => {
     </>
   );
 };
+
+const OFFSET_DEFAULT: [number, number] = [-16, -32];
+const OFFSET_SMALL: [number, number] = [-12, -24];


### PR DESCRIPTION
Added more information to the tooltip(#264 ). Please review.

![image](https://user-images.githubusercontent.com/67926235/193645130-f71142d2-6b42-4198-be35-4365f4c41277.png)
