### PR TITLE
Migrate fully to react-router-dom v6

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,8 +31,7 @@
     "react-redux": "7.2.8",
     "react-responsive": "9.0.0-beta.10",
     "react-router": "5.3.3",
-    "react-router-dom": "5.3.3",
-    "react-router-dom-v5-compat": "6.27.0",
+    "react-router-dom": "6",
     "redux": "4.2.0",
     "redux-toolbelt": "3.1.2"
   },

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -25,7 +25,7 @@ import UserProfile from "./pages/profile";
 import RecentMatches from "./pages/recent-matches/recent-matches";
 import Regions from "./pages/about/regions";
 import PlayersPage from "./pages/players";
-import { Routes, Route, CompatRouter } from "react-router-dom-v5-compat";
+import { Routes, Route, BrowserRouter } from "react-router-dom";
 
 const { Content } = Layout;
 
@@ -33,7 +33,7 @@ const App: React.FC = () => {
   return (
     <div className="App">
       <Layout className="layout">
-        <CompatRouter>
+        <BrowserRouter>
           <MainHeader />
           <Content>
             <ErrorBoundary>
@@ -64,7 +64,7 @@ const App: React.FC = () => {
             </ErrorBoundary>
           </Content>
           <MainFooter />
-        </CompatRouter>
+        </BrowserRouter>
       </Layout>
     </div>
   );

--- a/packages/web/src/components/alert-box-china.tsx
+++ b/packages/web/src/components/alert-box-china.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AlertBox } from "./alert-box";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../routes";
 
 export const AlertBoxChina: React.FC = () => {

--- a/packages/web/src/components/main-footer.tsx
+++ b/packages/web/src/components/main-footer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Footer } from "antd/es/layout/layout";
 import { Divider, Typography } from "antd";
-import { Link as RouterLink } from "react-router-dom-v5-compat";
+import { Link as RouterLink } from "react-router-dom";
 import config from "../config";
 import { RegionSelector } from "./region-selector";
 import { Helper } from "./helper";

--- a/packages/web/src/components/main-header.tsx
+++ b/packages/web/src/components/main-header.tsx
@@ -20,7 +20,7 @@ import {
   mostRecentGamesAppBase,
   regionsBase,
 } from "../titles";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import { doc, getFirestore, onSnapshot } from "firebase/firestore";
 import { ItemType } from "antd/lib/menu/hooks/useItems";
 

--- a/packages/web/src/components/main-home.tsx
+++ b/packages/web/src/components/main-home.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Card, Col, Row, Space, Typography } from "antd";
 import Meta from "antd/es/card/Meta";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../routes";
 import { commanderAndBulletinDate, lastPatchName } from "../config";
 import { doc, getFirestore, getDoc } from "firebase/firestore";

--- a/packages/web/src/pages/bulletins/bulletinList.tsx
+++ b/packages/web/src/pages/bulletins/bulletinList.tsx
@@ -7,7 +7,7 @@ import { ColumnsType } from "antd/es/table";
 import { ExportDate } from "../../components/export-date";
 import firebaseAnalytics from "../../analytics";
 import { Tip } from "../../components/tip";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../routes";
 import { ChangeEvent } from "react";
 import { useHistory } from "react-router";

--- a/packages/web/src/pages/commanders/commandersList.tsx
+++ b/packages/web/src/pages/commanders/commandersList.tsx
@@ -2,13 +2,12 @@ import React, { useEffect } from "react";
 import { Col, Row, List, Avatar, Typography } from "antd";
 import { getCommanderByRaces, getCommanderIconPath } from "../../coh/commanders";
 // import { useParams } from "react-router";
-import { useParams } from "react-router-dom-v5-compat";
+import { Link, useParams } from "react-router-dom";
 import { RaceName } from "../../coh/types";
 import routes from "../../routes";
 import { ExportDate } from "../../components/export-date";
 import { commanderBase } from "../../titles";
 import { capitalize } from "../../utils/helpers";
-import { Link } from "react-router-dom-v5-compat";
 import { Tip } from "../../components/tip";
 import { CommanderAbilitiesComponent } from "../../components/commander-abillities-component";
 

--- a/packages/web/src/pages/commanders/racePicker.tsx
+++ b/packages/web/src/pages/commanders/racePicker.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Col, Row } from "antd";
 
 import routes from "../../routes";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import { Tip } from "../../components/tip";
 import { getGeneralIconPath } from "../../coh/helpers";
 

--- a/packages/web/src/pages/ladders/leaderboards.tsx
+++ b/packages/web/src/pages/ladders/leaderboards.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   Switch,
 } from "antd";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import { useHistory } from "react-router";
 
 import { LaddersDataArrayObject, LaddersDataObject } from "../../coh/types";

--- a/packages/web/src/pages/live-matches/live-matches-table.tsx
+++ b/packages/web/src/pages/live-matches/live-matches-table.tsx
@@ -12,7 +12,7 @@ import {
   raceIds,
 } from "../../utils/table-functions";
 import { convertSteamNameToID, getGeneralIconPath } from "../../coh/helpers";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../routes";
 import { ColumnsType } from "antd/es/table";
 import { ConfigContext } from "../../config-context";

--- a/packages/web/src/pages/map-stats/map-stats-details.tsx
+++ b/packages/web/src/pages/map-stats/map-stats-details.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Row, Card, Radio, RadioChangeEvent, Space, Typography, Tooltip, Select } from "antd";
 import { MapBarChart } from "../../components/charts/maps-bar";
 import { mapStatsBase } from "../../titles";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import { FactionVsFactionCard } from "../../components/factions";
 import { useMediaQuery } from "react-responsive";
 import { MapsWinRateChart } from "../../components/charts/map-stats/maps-winrate-bar";

--- a/packages/web/src/pages/map-stats/map-stats-general-data-provider.tsx
+++ b/packages/web/src/pages/map-stats/map-stats-general-data-provider.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Typography } from "antd";
 import { Loading } from "../../components/loading";
 import { StatsDataObject, validStatsTypes } from "../../coh/types";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import firebaseAnalytics from "../../analytics";
 import MapStatsDetails from "./map-stats-details";
 import { doc, getDoc, getFirestore } from "firebase/firestore";

--- a/packages/web/src/pages/map-stats/map-stats-range-data-provider.tsx
+++ b/packages/web/src/pages/map-stats/map-stats-range-data-provider.tsx
@@ -6,7 +6,7 @@ import { firebase } from "../../firebase";
 import { Loading } from "../../components/loading";
 
 import { validStatsTypes } from "../../coh/types";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import MapStatsDetails from "./map-stats-details";
 
 const { Title } = Typography;

--- a/packages/web/src/pages/matches/all-matches-table.tsx
+++ b/packages/web/src/pages/matches/all-matches-table.tsx
@@ -24,7 +24,7 @@ import {
   raceIds,
 } from "../../utils/table-functions";
 import { convertSteamNameToID, getGeneralIconPath } from "../../coh/helpers";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../routes";
 import { useMediaQuery } from "react-responsive";
 import { BulbOutlined, DatabaseOutlined, PlusCircleOutlined } from "@ant-design/icons";

--- a/packages/web/src/pages/matches/last-matches-table.tsx
+++ b/packages/web/src/pages/matches/last-matches-table.tsx
@@ -13,7 +13,7 @@ import {
   getPlayerMapListFilter,
 } from "../../utils/table-functions";
 import "./tableStyle.css";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../routes";
 import { convertSteamNameToID, getGeneralIconPath } from "../../coh/helpers";
 import { BulbOutlined, DatabaseOutlined } from "@ant-design/icons";

--- a/packages/web/src/pages/matches/match-details-table.tsx
+++ b/packages/web/src/pages/matches/match-details-table.tsx
@@ -9,7 +9,7 @@ import firebaseAnalytics from "../../analytics";
 import { getBulletinData, getBulletinIconPath } from "../../coh/bulletins";
 import { getCommanderData, getCommanderIconPath } from "../../coh/commanders";
 import { CommanderAbility } from "../../coh/types";
-import { Link as RouterLink } from "react-router-dom-v5-compat";
+import { Link as RouterLink } from "react-router-dom";
 import { BulbOutlined } from "@ant-design/icons";
 
 const { Text } = Typography;

--- a/packages/web/src/pages/players/player-card/player-team-matches-table.tsx
+++ b/packages/web/src/pages/players/player-card/player-team-matches-table.tsx
@@ -5,7 +5,7 @@ import { LaddersDataArrayObject, PlayerCardDataArrayObject } from "../../../coh/
 import { CountryFlag } from "../../../components/country-flag";
 import { Switch, Table, Tooltip, Typography } from "antd";
 import { convertSteamNameToID, levelToText } from "../../../coh/helpers";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../../routes";
 import { convertTeamNames, formatTimeAgo, latestDate, percentageFormat } from "./helpers";
 import { Helper } from "../../../components/helper";

--- a/packages/web/src/pages/players/stats/player-stats.tsx
+++ b/packages/web/src/pages/players/stats/player-stats.tsx
@@ -7,7 +7,7 @@ import { Row } from "antd/es";
 import { Helper } from "../../../components/helper";
 import { Loading } from "../../../components/loading";
 import { AlertBox } from "../../../components/alert-box";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../../routes";
 import firebaseAnalytics from "../../../analytics";
 

--- a/packages/web/src/pages/recent-matches/recent-matches.tsx
+++ b/packages/web/src/pages/recent-matches/recent-matches.tsx
@@ -21,7 +21,7 @@ import {
   raceIds,
 } from "../../utils/table-functions";
 import { convertSteamNameToID, getGeneralIconPath } from "../../coh/helpers";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../../routes";
 import { getMapIconPath } from "../../coh/maps";
 import { AlertBox } from "../../components/alert-box";

--- a/packages/web/src/pages/stats/custom-stats-general-data-provider.tsx
+++ b/packages/web/src/pages/stats/custom-stats-general-data-provider.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Typography } from "antd";
 import { Loading } from "../../components/loading";
 import { StatsDataObject, statTypesInDbAsType, validStatsTypes } from "../../coh/types";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import CustomStatsDetails from "./custom-stats-details";
 import firebaseAnalytics from "../../analytics";
 import GeneralStats from "./general-stats";

--- a/packages/web/src/pages/stats/custom-stats-range-data-provider.tsx
+++ b/packages/web/src/pages/stats/custom-stats-range-data-provider.tsx
@@ -10,7 +10,7 @@ import {
   TypeAnalysisObject,
   validStatsTypes,
 } from "../../coh/types";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import CustomStatsDetails from "./custom-stats-details";
 import { StatsHeader } from "./stats-header";
 import GeneralStats from "./general-stats";

--- a/packages/web/src/pages/stats/old-stats.tsx
+++ b/packages/web/src/pages/stats/old-stats.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { useHistory, useParams } from "react-router";
 import routes from "../../routes";
 import { getPreviousWeekTimeStamp, useQuery } from "../../utils/helpers";
-import { Link, Routes, Route } from "react-router-dom-v5-compat";
+import { Link, Routes, Route } from "react-router-dom";
 
 /**
  * This is old stats format, it's used for redirect from the old links

--- a/packages/web/src/utils/helpers.ts
+++ b/packages/web/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 import { eachDayOfInterval, format } from "date-fns";
 
 import TimeAgo from "javascript-time-ago";

--- a/packages/web/src/utils/table-functions.tsx
+++ b/packages/web/src/utils/table-functions.tsx
@@ -5,7 +5,7 @@ import firebaseAnalytics from "../analytics";
 import { MatchPlayerDetailsTable } from "../pages/matches/match-details-table";
 import { SimplePieChart } from "../components/charts-match/simple-pie";
 import MatchDetails from "../pages/matches/match-details";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import routes from "../routes";
 import { DatabaseOutlined } from "@ant-design/icons";
 import { RelicIcon } from "../components/relic-icon";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,13 +2135,6 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.7.6":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.7.tgz#7ffb53c37a8f247c8c4d335e89cdf16a2e0d0fb6"
-  integrity sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/template@^7.16.0", "@babel/template@^7.3.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
@@ -10355,13 +10348,6 @@ history@4.10.1, history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-history@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
-  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
 hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -15567,27 +15553,13 @@ react-responsive@9.0.0-beta.10:
     prop-types "^15.6.1"
     shallow-equal "^1.2.1"
 
-react-router-dom-v5-compat@6.27.0:
+react-router-dom@6:
   version "6.27.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.27.0.tgz#19429aefa130ee151e6f4487d073d919ec22d458"
-  integrity sha512-hq5yCVoW73mljLhRjyzpYmooLNPR/xb17S3CTz9fe2/P7q821ivMEa9c8OtrAk2Bs83PcNAtst5okT/aUhJtgg==
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.27.0.tgz#8d7972a425fd75f91c1e1ff67e47240c5752dc3f"
+  integrity sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==
   dependencies:
     "@remix-run/router" "1.20.0"
-    history "^5.3.0"
     react-router "6.27.0"
-
-react-router-dom@5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.3.tgz#8779fc28e6691d07afcaf98406d3812fe6f11199"
-  integrity sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==
-  dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.3.3"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
 
 react-router@5.3.3:
   version "5.3.3"
@@ -17075,7 +17047,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17173,7 +17154,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17186,6 +17167,13 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.0, strip-ansi@^7.0.1:
   version "7.0.1"
@@ -18696,7 +18684,7 @@ workbox-window@6.4.2:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.4.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18709,6 +18697,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Changes to migrate to react-router-dom v6 fully, removed dependencies for react-router-dom-compat-v5